### PR TITLE
Add blue/green backend deployment manifests

### DIFF
--- a/kubernetes/blue/backend-blue.yaml
+++ b/kubernetes/blue/backend-blue.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend-blue
+  labels:
+    app: backend
+    version: blue
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: backend
+      version: blue
+  template:
+    metadata:
+      labels:
+        app: backend
+        version: blue
+    spec:
+      containers:
+      - name: backend
+        image: tu-usuario/devops-final-backend:blue-latest
+        ports:
+        - containerPort: 3005
+        env:
+        - name: DB_HOST
+          value: mysql-service
+        - name: DB_USER
+          value: "root"
+        - name: DB_PASSWORD
+          value: "12345"
+        - name: DB_NAME
+          value: "pokedex"
+        - name: JWT_SECRET
+          value: "defaultsecretkey"
+        - name: NODE_ENV
+          value: "production"
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "200m"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 3005
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 3005
+          initialDelaySeconds: 5
+          periodSeconds: 5 

--- a/kubernetes/blue/service-blue.yaml
+++ b/kubernetes/blue/service-blue.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend-blue-service
+  labels:
+    app: backend
+    version: blue
+spec:
+  selector:
+    app: backend
+    version: blue
+  ports:
+  - port: 80
+    targetPort: 3005
+    protocol: TCP
+  type: ClusterIP 

--- a/kubernetes/green/backend-green.yaml
+++ b/kubernetes/green/backend-green.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend-green
+  labels:
+    app: backend
+    version: green
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: backend
+      version: green
+  template:
+    metadata:
+      labels:
+        app: backend
+        version: green
+    spec:
+      containers:
+      - name: backend
+        image: marv7/devops-final
+        ports:
+        - containerPort: 3005
+        env:
+        - name: DB_HOST
+          value: mysql-service
+        - name: DB_USER
+          value: "root"
+        - name: DB_PASSWORD
+          value: "12345"
+        - name: DB_NAME
+          value: "pokedex"
+        - name: JWT_SECRET
+          value: "defaultsecretkey"
+        - name: NODE_ENV
+          value: "production"
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "200m"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 3005
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 3005
+          initialDelaySeconds: 5
+          periodSeconds: 5 


### PR DESCRIPTION
Introduces Kubernetes deployment and service YAML files for blue and green versions of the backend. This supports blue/green deployment strategies by defining separate deployments and a service for the blue backend.